### PR TITLE
feat: provision an opensearch instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,35 +32,47 @@ clean-networking-dev:
 services-dev:
 	cd networking
 	data_prepper_config_efs_id=$$(terraform output -raw data_prepper_config_efs_id | xargs)
-	data_prepper_target_group_arn=$$(terraform output -raw data_prepper_target_group_arn | xargs)
+	telemetry_collector_config_efs_id=$$(terraform output -raw telemetry_collector_config_efs_id | xargs)
+	telemetry_collector_target_group_arn=$$(terraform output -raw telemetry_collector_target_group_arn | xargs)
 	public_subnet_ids=$$(terraform output -json public_subnet_ids)
-	testnet_infra_security_group_id=$$(terraform output -raw testnet_infra_security_group_id | xargs)
+	telemetry_collector_security_group_id=$$(terraform output -raw telemetry_collector_security_group_id | xargs)
+	data_prepper_security_group_id=$$(terraform output -raw data_prepper_security_group_id | xargs)
+	data_prepper_service_registry_arn=$$(terraform output -raw data_prepper_service_registry_arn | xargs)
 	cd ..
 	cd services
 	terraform workspace select dev
 	terraform init
 	terraform apply -auto-approve \
 		-var data_prepper_config_efs_id=$$data_prepper_config_efs_id \
-		-var data_prepper_target_group_arn=$$data_prepper_target_group_arn \
+		-var telemetry_collector_config_efs_id=$$telemetry_collector_config_efs_id \
+		-var telemetry_collector_target_group_arn=$$telemetry_collector_target_group_arn \
 		-var "public_subnet_ids=$$public_subnet_ids" \
-		-var testnet_infra_security_group_id=$$testnet_infra_security_group_id
+		-var telemetry_collector_security_group_id=$$telemetry_collector_security_group_id \
+		-var data_prepper_security_group_id=$$data_prepper_security_group_id \
+		-var data_prepper_service_registry_arn=$$data_prepper_service_registry_arn
 
 .ONESHELL:
 clean-services-dev:
 	cd networking
 	data_prepper_config_efs_id=$$(terraform output -raw data_prepper_config_efs_id | xargs)
-	data_prepper_target_group_arn=$$(terraform output -raw data_prepper_target_group_arn | xargs)
+	telemetry_collector_config_efs_id=$$(terraform output -raw telemetry_collector_config_efs_id | xargs)
+	telemetry_collector_target_group_arn=$$(terraform output -raw telemetry_collector_target_group_arn | xargs)
 	public_subnet_ids=$$(terraform output -json public_subnet_ids)
-	testnet_infra_security_group_id=$$(terraform output -raw testnet_infra_security_group_id | xargs)
+	telemetry_collector_security_group_id=$$(terraform output -raw telemetry_collector_security_group_id | xargs)
+	data_prepper_security_group_id=$$(terraform output -raw data_prepper_security_group_id | xargs)
+	data_prepper_service_registry_arn=$$(terraform output -raw data_prepper_service_registry_arn | xargs)
 	cd ..
 	cd services
 	terraform workspace select dev
 	terraform init
 	terraform destroy -auto-approve \
 		-var data_prepper_config_efs_id=$$data_prepper_config_efs_id \
-		-var data_prepper_target_group_arn=$$data_prepper_target_group_arn \
+		-var telemetry_collector_config_efs_id=$$telemetry_collector_config_efs_id \
+		-var telemetry_collector_target_group_arn=$$telemetry_collector_target_group_arn \
 		-var "public_subnet_ids=$$public_subnet_ids" \
-		-var testnet_infra_security_group_id=$$testnet_infra_security_group_id
+		-var telemetry_collector_security_group_id=$$telemetry_collector_security_group_id \
+		-var data_prepper_security_group_id=$$data_prepper_security_group_id \
+		-var data_prepper_service_registry_arn=$$data_prepper_service_registry_arn
 
 .ONESHELL:
 clean-dev: clean-services-dev clean-networking-dev clean-opensearch-dev

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Defines infrastructure for hosting testnets (and supplementary tooling like Open
 
 ## OpenSearch Setup
 
-The AWS-hosted Elasticsearch service now uses OpenSearch. The use of OpenSearch requires at least two additional services: [the OpenTelemetry collector](https://opentelemetry.io/docs/collector/getting-started/) and the [Data Prepper](https://opensearch.org/docs/latest/data-prepper/get-started/).
+The AWS-hosted Elasticsearch service now uses OpenSearch. The use of OpenSearch requires at least two additional services: the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/getting-started/) and the [Data Prepper](https://opensearch.org/docs/latest/data-prepper/get-started/).
 
 We can host those services on ECS rather than using EC2 instances. The services are made publicly accessible through an EC2 network load balancer.
 
-The setup is not completely automated because the Data Prepper requires a configuration file pointing to the OpenSearch service, which must be provided through an EFS file system which is mounted to the container running on ECS. The EFS file system needs to be on the same VPC subnet where the service is running, so it can't be created in advance as a one-off step.
+The setup is not completely automated because both services require configuration files, which must be provided through EFS file systems that get mounted to the containers running on ECS. The file systems need to be on the same VPC subnet where the services are running, so they can't be created in advance as a one-off step.
 
 Here is the process for creating the infrastructure:
 * Run `make opensearch-dev` to provision the OpenSearch instance.
 * Run `make networking-dev` to create the VPC, load balancer and EFS file system required for running the additional services on ECS.
-* Spin up an EC2 instance on the VPC that was created and mount the EFS file system to it.
+* Spin up an EC2 instance on the VPC that was created and mount the Telemetry Collector and Data Prepper EFS file systems on it.
 * Fill in the placeholder values in the `pipelines.yml` file in this repository with the OpenSearch hostname, username and password.
-* Put the `pipelines.yml` at the root of the mounted EFS file system.
+* Put the `pipelines.yml` at the root of the mounted Data Prepper EFS file system.
+* Do the same thing for the `config.yaml` file for the OpenTelemetry Collector service, using its own file system.
 * Terminate the EC2 instance.
 * Run `make services-dev`.
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,23 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  batch: null
+
+exporters:
+  logging:
+  otlp/data-prepper:
+    endpoint: "data-prepper.dev-testnet-infra.local:21890"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/data-prepper, logging]
+    logs:
+      receivers: [otlp]
+      exporters: [otlp/data-prepper]

--- a/networking/main.tf
+++ b/networking/main.tf
@@ -26,64 +26,268 @@ module "vpc" {
   enable_dns_support   = true
 }
 
-resource "aws_security_group" "testnet_infra" {
-  name        = "${terraform.workspace}-${var.testnet_infra_security_group_name}"
-  description = "Connectivity for Elastic-related services."
+resource "aws_service_discovery_private_dns_namespace" "testnet_infra" {
+  name        = "${terraform.workspace}-testnet-infra.local"
+  description = "Service discovery for the Telemetry Collector and Data Prepper services"
+  vpc         = module.vpc.vpc_id
+}
+
+resource "aws_service_discovery_service" "data_prepper" {
+  name = "data-prepper"
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.testnet_infra.id
+    dns_records {
+      ttl = 10
+      type = "A"
+    }
+  }
+}
+
+#
+# Security group and network ACLs for debugging and working with the EFS mounts
+#
+resource "aws_security_group" "debugging" {
+  name        = "${terraform.workspace}-testnet-infra-debugging"
+  description = "Use for launching EC2 instances for populating EFS mounts and testing"
   vpc_id      = module.vpc.vpc_id
 }
 
 resource "aws_security_group_rule" "testnet_infra_ssh_ingress" {
   type              = "ingress"
+  description       = "Permits inbound SSH access"
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.testnet_infra.id
+  security_group_id = aws_security_group.debugging.id
 }
 
 resource "aws_security_group_rule" "testnet_infra_nfs_ingress" {
   type              = "ingress"
+  description       = "Permits inbound NFS traffic for the EFS volume attachment"
   from_port         = 2049
   to_port           = 2049
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.testnet_infra.id
+  security_group_id = aws_security_group.debugging.id
 }
 
 resource "aws_security_group_rule" "testnet_infra_nfs_egress" {
   type              = "egress"
+  description       = "Permits outbound NFS traffic for the EFS volume attachment"
   from_port         = 2049
   to_port           = 2049
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.testnet_infra.id
-}
-
-resource "aws_security_group_rule" "testnet_infra_data_prepper_ingress" {
-  type              = "ingress"
-  from_port         = 4900
-  to_port           = 4900
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.testnet_infra.id
+  security_group_id = aws_security_group.debugging.id
 }
 
 resource "aws_security_group_rule" "testnet_infra_https_egress" {
   type              = "egress"
+  description       = "Permits HTTPS internet access for debugging and testing"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.testnet_infra.id
+  security_group_id = aws_security_group.debugging.id
 }
 
 resource "aws_security_group_rule" "testnet_infra_http_egress" {
   type              = "egress"
+  description       = "Permits HTTP internet access for debugging and testing"
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.testnet_infra.id
+  security_group_id = aws_security_group.debugging.id
+}
+
+resource "aws_security_group_rule" "testnet_infra_data_prepper_http_egress" {
+  type              = "egress"
+  description       = "Permits TCP access to the Data Prepper"
+  from_port         = 4900
+  to_port           = 4900
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.debugging.id
+}
+
+resource "aws_security_group_rule" "testnet_infra_data_prepper_egress" {
+  type              = "egress"
+  description       = "Permits TCP access to the Data Prepper"
+  from_port         = 21890
+  to_port           = 21890
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.debugging.id
+}
+
+#
+# Security group and network ACLs for the Data Prepper service
+#
+resource "aws_security_group" "data_prepper" {
+  name        = "${terraform.workspace}-${var.data_prepper_security_group_name}"
+  description = "Connectivity for the Data Prepper services."
+  vpc_id      = module.vpc.vpc_id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_data_prepper_http_ingress" {
+  type                     = "ingress"
+  description              = "Permits inbound Telemetry Collector traffic access to the Data Prepper"
+  from_port                = 4900
+  to_port                  = 4900
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.telemetry_collector.id
+  security_group_id        = aws_security_group.data_prepper.id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_data_prepper_ingress" {
+  type                     = "ingress"
+  description              = "Permits inbound debugging traffic access to the Data Prepper"
+  from_port                = 21890
+  to_port                  = 21890
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.telemetry_collector.id
+  security_group_id        = aws_security_group.data_prepper.id
+}
+
+resource "aws_security_group_rule" "debugging_data_prepper_http_ingress" {
+  type                     = "ingress"
+  description              = "Permits inbound debugging traffic access to the Data Prepper"
+  from_port                = 4900
+  to_port                  = 4900
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.debugging.id
+  security_group_id        = aws_security_group.data_prepper.id
+}
+
+resource "aws_security_group_rule" "debugging_data_prepper_ingress" {
+  type                     = "ingress"
+  description              = "Permits inbound debugging traffic access to the Data Prepper"
+  from_port                = 21890
+  to_port                  = 21890
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.debugging.id
+  security_group_id        = aws_security_group.data_prepper.id
+}
+
+resource "aws_security_group_rule" "data_prepper_nfs_ingress" {
+  type              = "ingress"
+  description       = "Permits inbound NFS traffic for the EFS volume attachment"
+  from_port         = 2049
+  to_port           = 2049
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.data_prepper.id
+}
+
+resource "aws_security_group_rule" "data_prepper_nfs_egress" {
+  type              = "egress"
+  description       = "Permits outbound NFS traffic for the EFS volume attachment"
+  from_port         = 2049
+  to_port           = 2049
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.data_prepper.id
+}
+
+resource "aws_security_group_rule" "data_prepper_https_egress" {
+  type              = "egress"
+  description       = "Permits HTTPS internet access for pulling the container"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.data_prepper.id
+}
+
+resource "aws_security_group_rule" "data_prepper_http_egress" {
+  type              = "egress"
+  description       = "Permits HTTP internet access for pulling the container"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.data_prepper.id
+}
+
+#
+# Security group and network ACLs for the Telemetry Collector service
+#
+resource "aws_security_group" "telemetry_collector" {
+  name        = "${terraform.workspace}-${var.telemetry_collector_security_group_name}"
+  description = "Connectivity for the Telemetry Collector services."
+  vpc_id      = module.vpc.vpc_id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_nfs_ingress" {
+  type              = "ingress"
+  description       = "Permits inbound NFS traffic for the EFS volume attachment"
+  from_port         = 2049
+  to_port           = 2049
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.telemetry_collector.id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_nfs_egress" {
+  type              = "egress"
+  description       = "Permits outbound NFS traffic for the EFS volume attachment"
+  from_port         = 2049
+  to_port           = 2049
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.telemetry_collector.id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_data_prepper_http_egress" {
+  type                     = "egress"
+  description              = "Permits outbound Telemetry Collector traffic access to the Data Prepper"
+  from_port                = 4900
+  to_port                  = 4900
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.data_prepper.id
+  security_group_id        = aws_security_group.telemetry_collector.id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_data_prepper_egress" {
+  type                     = "egress"
+  description              = "Permits outbound Telemetry Collector traffic access to the Data Prepper"
+  from_port                = 21890
+  to_port                  = 21890
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.data_prepper.id
+  security_group_id        = aws_security_group.telemetry_collector.id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_grpc" {
+  type              = "ingress"
+  description       = "Permits inbound public access to the Telemetry Collector"
+  from_port         = 4317
+  to_port           = 4317
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.telemetry_collector.id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_https_egress" {
+  type              = "egress"
+  description       = "Permits HTTPS internet access for pulling the container"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.telemetry_collector.id
+}
+
+resource "aws_security_group_rule" "telemetry_collector_http_egress" {
+  type              = "egress"
+  description       = "Permits HTTP internet access for pulling the container"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.telemetry_collector.id
 }
 
 resource "aws_lb" "testnet_infra" {
@@ -92,25 +296,28 @@ resource "aws_lb" "testnet_infra" {
   subnets            = module.vpc.public_subnets
 }
 
-resource "aws_lb_target_group" "data_prepper" {
-  name        = "${terraform.workspace}-data-prepper"
+resource "aws_lb_target_group" "telemetry_collector" {
+  name        = "${terraform.workspace}-telemetry-collector"
   target_type = "ip"
-  port        = 4900
+  port        = 4317
   protocol    = "TCP"
   vpc_id      = module.vpc.vpc_id
 }
 
-resource "aws_lb_listener" "data_prepper" {
+resource "aws_lb_listener" "telemetry_collector" {
   load_balancer_arn = aws_lb.testnet_infra.arn
-  port              = "4900"
+  port              = "4317"
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.data_prepper.arn
+    target_group_arn = aws_lb_target_group.telemetry_collector.arn
   }
 }
 
+#
+# The EFS file system for the Data Prepper service
+#
 resource "aws_efs_file_system" "data_prepper_config" {
   encrypted = true
   tags = {
@@ -121,15 +328,41 @@ resource "aws_efs_file_system" "data_prepper_config" {
 resource "aws_efs_mount_target" "data_prepper_config_public_subnet" {
   file_system_id  = aws_efs_file_system.data_prepper_config.id
   subnet_id       = module.vpc.public_subnets[0]
-  security_groups = [aws_security_group.testnet_infra.id]
+  security_groups = [aws_security_group.data_prepper.id, aws_security_group.debugging.id]
 }
 
 resource "aws_efs_mount_target" "data_prepper_config_public_subnet2" {
   file_system_id  = aws_efs_file_system.data_prepper_config.id
   subnet_id       = module.vpc.public_subnets[1]
-  security_groups = [aws_security_group.testnet_infra.id]
+  security_groups = [aws_security_group.data_prepper.id, aws_security_group.debugging.id]
 }
 
 resource "aws_cloudwatch_log_group" "data_prepper" {
   name = "/ecs/${terraform.workspace}-opensearch-data-prepper"
+}
+
+#
+# The EFS file system for the Telemetry Collector service
+#
+resource "aws_efs_file_system" "telemetry_collector_config" {
+  encrypted = true
+  tags = {
+    Name = "${terraform.workspace}-telemetry_collector_config"
+  }
+}
+
+resource "aws_efs_mount_target" "telemetry_collector_config_public_subnet" {
+  file_system_id  = aws_efs_file_system.telemetry_collector_config.id
+  subnet_id       = module.vpc.public_subnets[0]
+  security_groups = [aws_security_group.telemetry_collector.id, aws_security_group.debugging.id]
+}
+
+resource "aws_efs_mount_target" "telemetry_collector_config_public_subnet2" {
+  file_system_id  = aws_efs_file_system.telemetry_collector_config.id
+  subnet_id       = module.vpc.public_subnets[1]
+  security_groups = [aws_security_group.telemetry_collector.id, aws_security_group.debugging.id]
+}
+
+resource "aws_cloudwatch_log_group" "telemetry_collector" {
+  name = "/ecs/${terraform.workspace}-opensearch-telemetry-collector"
 }

--- a/networking/outputs.tf
+++ b/networking/outputs.tf
@@ -2,14 +2,26 @@ output "public_subnet_ids" {
   value = module.vpc.public_subnets
 }
 
-output "data_prepper_target_group_arn" {
-  value = aws_lb_target_group.data_prepper.arn
-}
-
 output "data_prepper_config_efs_id" {
   value = aws_efs_file_system.data_prepper_config.id
 }
 
-output "testnet_infra_security_group_id" {
-  value = aws_security_group.testnet_infra.id
+output "data_prepper_security_group_id" {
+  value = aws_security_group.data_prepper.id
+}
+
+output "telemetry_collector_target_group_arn" {
+  value = aws_lb_target_group.telemetry_collector.arn
+}
+
+output "telemetry_collector_config_efs_id" {
+  value = aws_efs_file_system.telemetry_collector_config.id
+}
+
+output "telemetry_collector_security_group_id" {
+  value = aws_security_group.telemetry_collector.id
+}
+
+output "data_prepper_service_registry_arn" {
+  value = aws_service_discovery_service.data_prepper.arn
 }

--- a/networking/variables.tf
+++ b/networking/variables.tf
@@ -13,7 +13,12 @@ variable "testnet_infra_vpc_name" {
   description = "The name of the testnet infra VPC"
 }
 
-variable "testnet_infra_security_group_name" {
-  default = "testnet_infra"
-  description = "The name of the testnet infra security group"
+variable "telemetry_collector_security_group_name" {
+  default = "telemetry_collector"
+  description = "The name of the telemetry collector security group"
+}
+
+variable "data_prepper_security_group_name" {
+  default = "data_prepper"
+  description = "The name of the data prepper security group"
 }

--- a/opensearch/variables.tf
+++ b/opensearch/variables.tf
@@ -18,7 +18,7 @@ variable "master_user_password" {
 }
 
 variable "instance_type" {
-  default = "t3.small.search"
+  default = "m6g.large.search"
   description = "The type of instance to be used to run the OpenSearch nodes"
 }
 

--- a/pipelines.yml
+++ b/pipelines.yml
@@ -1,4 +1,5 @@
 otel-trace-pipeline:
+  workers: 2
   delay: "100"
   source:
     otel_trace_source:
@@ -15,6 +16,7 @@ otel-trace-pipeline:
     - pipeline:
         name: "service-map-pipeline"
 raw-pipeline:
+  workers: 2
   delay: "3000"
   source:
     pipeline:
@@ -34,8 +36,9 @@ raw-pipeline:
         hosts: ["{{ opensearch_domain_url }}"]
         username: "{{ opensearch_username }}"
         password: "{{ opensearch_password }}"
-        index: trace-analytics-raw
+        index_type: trace-analytics-raw
 service-map-pipeline:
+  workers: 2
   delay: "100"
   source:
     pipeline:
@@ -52,4 +55,4 @@ service-map-pipeline:
         hosts: ["{{ opensearch_domain_url }}"]
         username: "{{ opensearch_username }}"
         password: "{{ opensearch_password }}"
-        index: trace-analytics-raw
+        index_type: trace-analytics-service-map

--- a/services/main.tf
+++ b/services/main.tf
@@ -84,14 +84,92 @@ resource "aws_ecs_service" "data_prepper" {
   task_definition = aws_ecs_task_definition.data_prepper.arn
   desired_count   = 2
   launch_type     = "FARGATE"
+  network_configuration {
+    subnets          = var.public_subnet_ids
+    security_groups  = [var.data_prepper_security_group_id]
+    assign_public_ip = true
+  }
+  service_registries {
+    registry_arn = var.data_prepper_service_registry_arn
+  }
+}
+
+resource "aws_ecs_task_definition" "telemetry_collector" {
+  family                   = "${terraform.workspace}-opensearch-telemetry-collector"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 1024
+  memory                   = 2048
+  execution_role_arn       = var.ecs_testnet_infra_iam_role_arn
+  task_role_arn            = var.ecs_testnet_infra_iam_role_arn
+  container_definitions    = <<TASK_DEFINITION
+[
+    {
+        "name": "${terraform.workspace}-opensearch-telemetry-collector",
+        "image": "otel/opentelemetry-collector:0.69.0",
+        "cpu": 0,
+        "memoryReservation": 2048,
+        "portMappings": [
+            {
+                "containerPort": 4317,
+                "hostPort": 4317,
+                "protocol": "tcp"
+            }
+        ],
+        "essential": true,
+        "entryPoint": [],
+        "command": [],
+        "environment": [],
+        "mountPoints": [
+            {
+                "sourceVolume": "opensearch-telemetry-collector-config",
+                "containerPath": "/etc/otelcol"
+            }
+        ],
+        "volumesFrom": [],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "/ecs/${terraform.workspace}-opensearch-telemetry-collector",
+                "awslogs-region": "eu-west-2",
+                "awslogs-stream-prefix": "ecs"
+            }
+        }
+    }
+]
+TASK_DEFINITION
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+  volume {
+    name = "opensearch-telemetry-collector-config"
+    efs_volume_configuration {
+      file_system_id          = var.telemetry_collector_config_efs_id
+      root_directory          = "/"
+      transit_encryption      = "ENABLED"
+      authorization_config {
+        iam                   = "ENABLED"
+      }
+    }
+  }
+}
+
+resource "aws_ecs_service" "telemetry_collector" {
+  name            = "${terraform.workspace}-opensearch-telemetry-collector"
+  cluster         = aws_ecs_cluster.testnet_infra.id
+  task_definition = aws_ecs_task_definition.telemetry_collector.arn
+  desired_count   = 2
+  launch_type     = "FARGATE"
   load_balancer {
-    target_group_arn = var.data_prepper_target_group_arn
-    container_port   = 4900
-    container_name   = "${terraform.workspace}-opensearch-data-prepper"
+    target_group_arn = var.telemetry_collector_target_group_arn
+    container_port   = 4317
+    container_name   = "${terraform.workspace}-opensearch-telemetry-collector"
   }
   network_configuration {
     subnets          = var.public_subnet_ids
-    security_groups  = [var.testnet_infra_security_group_id]
+    security_groups  = [var.telemetry_collector_security_group_id]
     assign_public_ip = true
   }
 }

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -12,8 +12,12 @@ variable "data_prepper_config_efs_id" {
   description = "The ID of the EFS file system for the data prepper service"
 }
 
-variable "data_prepper_target_group_arn" {
-  description = "The ARN of the target group for the data prepper service"
+variable "telemetry_collector_config_efs_id" {
+  description = "The ID of the EFS file system for the telemetry collector service"
+}
+
+variable "telemetry_collector_target_group_arn" {
+  description = "The ARN of the target group for the telemetry collector service"
 }
 
 variable "public_subnet_ids" {
@@ -21,6 +25,14 @@ variable "public_subnet_ids" {
   type = list
 }
 
-variable "testnet_infra_security_group_id" {
-  description = "The ID of the security group for the services"
+variable "telemetry_collector_security_group_id" {
+  description = "The ID of the security group for Telemetry Collector service"
+}
+
+variable "data_prepper_security_group_id" {
+  description = "The ID of the security group for Data Prepper service"
+}
+
+variable "data_prepper_service_registry_arn" {
+  description = "The ARN of the Data Prepper service registry for DNS usage in the VPC"
 }


### PR DESCRIPTION
**feat: deploy open telemetry collector**

The Telemetry Collector is also deployed as an ECS service.

The Data Prepper is registered with service discovery so that the Telemetry Collector can refer to
it by a DNS name. The ECS infrastructure takes care of associating the replicated ECS tasks with
private DNS records in Route 53.

Each service is deployed in its own security group and all the network ACLs are defined. This
involves defining all the inbound and outbound rules explicitly.

**chore: adding secrets file**

This should be encrypted with git-crypt.

**feat: provision an opensearch instance**

Rather than rolling our own ELK stack, we decided to opt for the AWS-hosted service, which now uses
OpenSearch, which is the new open source version of Elastic. Sending the telemetry information from
the node to OpenSearch requires two services: the OpenTelemetry data collector and the Data Prepper.
We host these on ECS rather than using EC2 instances.

There are actually three different Terraform runs here. There is an explanation for this in the
README, which you can see in the diff.

The whole process is not completely automated, but it would definitely be possible to do it at some
later stage.
