### PR TITLE
chore: upgrade opensearch to m6g.2xlarge.search

### DIFF
--- a/opensearch/variables.tf
+++ b/opensearch/variables.tf
@@ -18,7 +18,7 @@ variable "master_user_password" {
 }
 
 variable "instance_type" {
-  default = "m6g.large.search"
+  default = "m6g.2xlarge.search"
   description = "The type of instance to be used to run the OpenSearch nodes"
 }
 


### PR DESCRIPTION
It seems like the current m6g.large.search configuration is struggling a bit, so we're going to try this new size, which is 8vCPU and 32GB of RAM.

The plan implies the upgrade will not cause a whole new stack:
```
❮ terraform plan -var-file=secrets.tfvars
aws_cloudwatch_log_resource_policy.testnet_elasticsearch: Refreshing state... [id=testnet-infra-dev]
aws_cloudwatch_log_group.testnet_elasticsearch: Refreshing state... [id=testnet-infra-dev]
aws_opensearch_domain.testnet_dev: Refreshing state... [id=arn:aws:es:eu-west-2:389640522532:domain/testnet-infra-dev]
aws_elasticsearch_domain_policy.access_kibana_and_put_data: Refreshing state... [id=esd-policy-testnet-infra-dev]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_opensearch_domain.testnet_dev will be updated in-place
  ~ resource "aws_opensearch_domain" "testnet_dev" {
        id               = "arn:aws:es:eu-west-2:389640522532:domain/testnet-infra-dev"
        tags             = {}
        # (9 unchanged attributes hidden)

      ~ cluster_config {
          ~ instance_type            = "m6g.large.search" -> "m6g.2xlarge.search"
            # (6 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }

        # (8 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```