### PR TITLE
chore: increase capacity of services

### DIFF
--- a/services/main.tf
+++ b/services/main.tf
@@ -20,8 +20,8 @@ resource "aws_ecs_task_definition" "data_prepper" {
   family                   = "${terraform.workspace}-opensearch-data-prepper"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 1024
-  memory                   = 2048
+  cpu                      = 2048
+  memory                   = 4096
   execution_role_arn       = var.ecs_testnet_infra_iam_role_arn
   task_role_arn            = var.ecs_testnet_infra_iam_role_arn
   container_definitions    = <<TASK_DEFINITION
@@ -98,8 +98,8 @@ resource "aws_ecs_task_definition" "telemetry_collector" {
   family                   = "${terraform.workspace}-opensearch-telemetry-collector"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 1024
-  memory                   = 2048
+  cpu                      = 2048
+  memory                   = 4096
   execution_role_arn       = var.ecs_testnet_infra_iam_role_arn
   task_role_arn            = var.ecs_testnet_infra_iam_role_arn
   container_definitions    = <<TASK_DEFINITION


### PR DESCRIPTION
Both the Telemetry Collector and Data Prepper have the capacity of their services increased to 2xCPU and 4GB of memory. There are two replicated services, so this means a combined total of 4xCPU and 8GB of memory.

We can see if this combination is better and keep increasing as we go.