### PR TITLE
feat: run testnets on AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,32 @@ clean-networking-dev:
 	terraform destroy -auto-approve
 
 .ONESHELL:
+dns-dev:
+	cd networking
+	vpc_id=$$(terraform output -raw vpc_id | xargs)
+	hosted_zone_id=$$(terraform output -raw hosted_zone_id | xargs)
+	cd ..
+	echo "Getting name servers for the dev-testnet-infra.local private DNS zone..."
+	name_servers=($$(aws route53 list-resource-record-sets \
+		--hosted-zone-id $$hosted_zone_id | \
+		jq -r '.ResourceRecordSets[] | select(.Type == "NS") | .ResourceRecords[].Value'))
+	echo "Looking up name server IPs..."
+	ips="AmazonProvidedDNS"
+	for i in 0 1 2; do
+		ns=$${name_servers[$$i]}
+		ip=$$(nslookup $$ns | awk 'NR==6 {print $$2; exit}')
+		ips="$$ips $$ip"
+	done
+	echo "Done"
+	ips=$$(echo -n $$ips | tr ' ' ',')
+	echo -n "Creating DHCP options set..."
+	dhcp_options_set_id=$$(aws ec2 create-dhcp-options \
+		--dhcp-configurations "Key=domain-name,Values=dev-testnet-infra.local" "Key=domain-name-servers,Values=$$ips" | \
+		jq -r '.DhcpOptions.DhcpOptionsId')
+	aws ec2 associate-dhcp-options --dhcp-options-id $$dhcp_options_set_id --vpc-id $$vpc_id
+	echo "Done"
+
+.ONESHELL:
 services-dev:
 	cd networking
 	data_prepper_config_efs_id=$$(terraform output -raw data_prepper_config_efs_id | xargs)
@@ -38,6 +64,7 @@ services-dev:
 	telemetry_collector_security_group_id=$$(terraform output -raw telemetry_collector_security_group_id | xargs)
 	data_prepper_security_group_id=$$(terraform output -raw data_prepper_security_group_id | xargs)
 	data_prepper_service_registry_arn=$$(terraform output -raw data_prepper_service_registry_arn | xargs)
+	telemetry_collector_service_registry_arn=$$(terraform output -raw telemetry_collector_service_registry_arn | xargs)
 	cd ..
 	cd services
 	terraform workspace select dev
@@ -49,7 +76,8 @@ services-dev:
 		-var "public_subnet_ids=$$public_subnet_ids" \
 		-var telemetry_collector_security_group_id=$$telemetry_collector_security_group_id \
 		-var data_prepper_security_group_id=$$data_prepper_security_group_id \
-		-var data_prepper_service_registry_arn=$$data_prepper_service_registry_arn
+		-var data_prepper_service_registry_arn=$$data_prepper_service_registry_arn \
+		-var telemetry_collector_service_registry_arn=$$telemetry_collector_service_registry_arn
 
 .ONESHELL:
 clean-services-dev:
@@ -61,6 +89,7 @@ clean-services-dev:
 	telemetry_collector_security_group_id=$$(terraform output -raw telemetry_collector_security_group_id | xargs)
 	data_prepper_security_group_id=$$(terraform output -raw data_prepper_security_group_id | xargs)
 	data_prepper_service_registry_arn=$$(terraform output -raw data_prepper_service_registry_arn | xargs)
+	telemetry_collector_service_registry_arn=$$(terraform output -raw telemetry_collector_service_registry_arn | xargs)
 	cd ..
 	cd services
 	terraform workspace select dev
@@ -72,7 +101,8 @@ clean-services-dev:
 		-var "public_subnet_ids=$$public_subnet_ids" \
 		-var telemetry_collector_security_group_id=$$telemetry_collector_security_group_id \
 		-var data_prepper_security_group_id=$$data_prepper_security_group_id \
-		-var data_prepper_service_registry_arn=$$data_prepper_service_registry_arn
+		-var data_prepper_service_registry_arn=$$data_prepper_service_registry_arn \
+		-var telemetry_collector_service_registry_arn=$$telemetry_collector_service_registry_arn
 
 .ONESHELL:
 clean-dev: clean-services-dev clean-networking-dev clean-opensearch-dev

--- a/networking/main.tf
+++ b/networking/main.tf
@@ -43,6 +43,17 @@ resource "aws_service_discovery_service" "data_prepper" {
   }
 }
 
+resource "aws_service_discovery_service" "telemetry_collector" {
+  name = "telemetry-collector"
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.testnet_infra.id
+    dns_records {
+      ttl = 10
+      type = "A"
+    }
+  }
+}
+
 #
 # Security group and network ACLs for debugging and working with the EFS mounts
 #
@@ -92,6 +103,26 @@ resource "aws_security_group_rule" "testnet_infra_https_egress" {
   security_group_id = aws_security_group.debugging.id
 }
 
+resource "aws_security_group_rule" "debugging_data_prepper_egress" {
+  type              = "egress"
+  description       = "Permits access to the Data Prepper service"
+  from_port         = 4317
+  to_port           = 4317
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.debugging.id
+}
+
+resource "aws_security_group_rule" "debugging_sn_node_egress" {
+  type              = "egress"
+  description       = "Permits outbound access for Safe Node"
+  from_port         = 12000
+  to_port           = 12000
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.debugging.id
+}
+
 resource "aws_security_group_rule" "testnet_infra_http_egress" {
   type              = "egress"
   description       = "Permits HTTP internet access for debugging and testing"
@@ -118,6 +149,16 @@ resource "aws_security_group_rule" "testnet_infra_data_prepper_egress" {
   from_port         = 21890
   to_port           = 21890
   protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.debugging.id
+}
+
+resource "aws_security_group_rule" "debugging_sn_node_ingress" {
+  type              = "ingress"
+  description       = "Permits inbound access for Safe Node"
+  from_port         = 12000
+  to_port           = 12000
+  protocol          = "udp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.debugging.id
 }

--- a/networking/outputs.tf
+++ b/networking/outputs.tf
@@ -1,3 +1,11 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "hosted_zone_id" {
+  value = aws_service_discovery_private_dns_namespace.testnet_infra.hosted_zone
+}
+
 output "public_subnet_ids" {
   value = module.vpc.public_subnets
 }
@@ -24,4 +32,8 @@ output "telemetry_collector_security_group_id" {
 
 output "data_prepper_service_registry_arn" {
   value = aws_service_discovery_service.data_prepper.arn
+}
+
+output "telemetry_collector_service_registry_arn" {
+  value = aws_service_discovery_service.telemetry_collector.arn
 }

--- a/services/main.tf
+++ b/services/main.tf
@@ -172,4 +172,7 @@ resource "aws_ecs_service" "telemetry_collector" {
     security_groups  = [var.telemetry_collector_security_group_id]
     assign_public_ip = true
   }
+  service_registries {
+    registry_arn = var.telemetry_collector_service_registry_arn
+  }
 }

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -36,3 +36,7 @@ variable "data_prepper_security_group_id" {
 variable "data_prepper_service_registry_arn" {
   description = "The ARN of the Data Prepper service registry for DNS usage in the VPC"
 }
+
+variable "telemetry_collector_service_registry_arn" {
+  description = "The ARN of the Telemetry Collector service registry for DNS usage in the VPC"
+}


### PR DESCRIPTION
- 4b0e484 **feat: run testnets on AWS**

  Provides extensions necessary for running testnets on AWS:

  * Both ingress and egress traffic on port 12000 was opened for UDP on the security group where EC2
    instances will run.
  * The Telemetry Collector service was added to service discovery, since the EC2 instances now need
    to be able to talk to this service.
  * A `dns` target was added to the Makefile for creating a DHCP options set which gets assigned to
    the VPC and is then used by the EC2 instances so they can refer to the Telemetry Collector and the
    Data Prepper services by their DNS entries.

- 6777e01 **chore: new data prepper and telemetry collector config**

  The documentation for the Data Prepper was very recently updated to provide new default values for
  the buffer settings. These seem to make the Telemetry Collector and the Data Prepper work better
  together.

  The Telemetry Collector was also updated to use a batch processor, which is recommended in the docs
  for trace analytics:
  https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors