### PR TITLE
chore: new data prepper and telemetry collector config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,10 @@ receivers:
       grpc:
 
 processors:
-  batch: null
+  batch:
+    send_batch_size: 8192
+    send_batch_max_size: 0
+    timeout: 200
 
 exporters:
   logging:

--- a/pipelines.yml
+++ b/pipelines.yml
@@ -8,8 +8,8 @@ otel-trace-pipeline:
         unauthenticated:
   buffer:
     bounded_blocking:
-      buffer_size: 512
-      batch_size: 8
+      buffer_size: 25600
+      batch_size: 400
   sink:
     - pipeline:
         name: "raw-pipeline"
@@ -23,8 +23,8 @@ raw-pipeline:
       name: "otel-trace-pipeline"
   buffer:
     bounded_blocking:
-      buffer_size: 512
-      batch_size: 64
+      buffer_size: 25600
+      batch_size: 3200
   processor:
     - otel_trace_raw:
     - otel_trace_group:
@@ -48,8 +48,8 @@ service-map-pipeline:
         window_duration: 180
   buffer:
     bounded_blocking:
-      buffer_size: 512
-      batch_size: 8
+      buffer_size: 25600
+      batch_size: 400
   sink:
     - opensearch:
         hosts: ["{{ opensearch_domain_url }}"]


### PR DESCRIPTION
The documentation for the Data Prepper was very recently updated to provide new default values for the buffer settings. These seem to make the Telemetry Collector and the Data Prepper work better together.

The Telemetry Collector was also updated to use a batch processor, which is recommended in the docs for trace analytics:
https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors