### PR TITLE
chore: open port 12001 for node rpc

### DIFF
--- a/networking/main.tf
+++ b/networking/main.tf
@@ -134,3 +134,13 @@ resource "aws_security_group_rule" "testnet_sn_node_ingress" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.testnet.id
 }
+
+resource "aws_security_group_rule" "testnet_sn_node_rpc_admin_ingress" {
+  type              = "ingress"
+  description       = "Permits inbound access for Safe Node RCP admin"
+  from_port         = 12001
+  to_port           = 12001
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.testnet.id
+}


### PR DESCRIPTION
We need this in the automated process for spinning up testnets, since we query the genesis node to get its peer ID.